### PR TITLE
[PAX-3846] Add support live activities

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sideshow/apns2/token"
@@ -22,6 +23,8 @@ import (
 const (
 	HostDevelopment = "https://api.sandbox.push.apple.com"
 	HostProduction  = "https://api.push.apple.com"
+
+	LiveActivityTopicHeaderSuffix = "push-type.liveactivity"
 )
 
 // DefaultHost is a mutable var for testing purposes
@@ -215,7 +218,14 @@ func (c *Client) setTokenHeader(r *http.Request) {
 func setHeaders(r *http.Request, n *Notification) {
 	r.Header.Set("Content-Type", "application/json; charset=utf-8")
 	if n.Topic != "" {
-		r.Header.Set("apns-topic", n.Topic)
+		topicHeader := n.Topic
+
+		if n.PushType == PushTypeLiveActivity &&
+			!strings.HasSuffix(topicHeader, LiveActivityTopicHeaderSuffix) {
+			topicHeader = strings.Join([]string{topicHeader, LiveActivityTopicHeaderSuffix}, ".")
+		}
+
+		r.Header.Set("apns-topic", topicHeader)
 	}
 	if n.ApnsID != "" {
 		r.Header.Set("apns-id", n.ApnsID)
@@ -234,5 +244,4 @@ func setHeaders(r *http.Request, n *Notification) {
 	} else {
 		r.Header.Set("apns-push-type", string(PushTypeAlert))
 	}
-
 }

--- a/client_test.go
+++ b/client_test.go
@@ -211,6 +211,34 @@ func TestClientPushWithContext(t *testing.T) {
 	assert.Equal(t, res.ApnsID, apnsID)
 }
 
+func TestClientPushWithContextWithRequestCallbacks(t *testing.T) {
+	n := mockNotification()
+	n.PushType = apns.PushTypeLiveActivity
+	n.Topic = "com.testapp"
+
+	var apnsID = "02ABC856-EF8D-4E49-8F15-7B8A61D978D6"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("apns-id", apnsID)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	mockedClient := mockClient(server.URL)
+
+	mockedClient.AddRequestCallback(func(req *http.Request) {
+		assert.Equal(t, "com.testapp.push-type.liveactivity", req.Header.Get("apns-topic"))
+	})
+
+	mockedClient.AddRequestCallback(func(req *http.Request) {
+		assert.Equal(t, string(apns.PushTypeLiveActivity), req.Header.Get("apns-push-type"))
+	})
+
+	res, err := mockedClient.PushWithContext(context.Background(), n)
+	assert.Nil(t, err)
+	assert.Equal(t, res.ApnsID, apnsID)
+}
+
 func TestClientPushWithNilContext(t *testing.T) {
 	n := mockNotification()
 	var apnsID = "02ABC856-EF8D-4E49-8F15-7B8A61D978D6"

--- a/notification.go
+++ b/notification.go
@@ -63,6 +63,14 @@ const (
 	// contact the MDM server. If you set this push type, you must use the topic
 	// from the UID attribute in the subject of your MDM push certificate.
 	PushTypeMDM EPushType = "mdm"
+
+	// The push type to signal changes to a live activity session. If you set
+	// this push type, the apns-topic header field must use your app’s bundle
+	// ID with.push-type.liveactivity appended to the end. For more information,
+	// see Updating and ending your Live Activity with ActivityKit push notifications.
+	// The liveactivity push type isn’t available on watchOS, macOS, and tvOS.
+	// It’s recommended on iOS and iPadOS.
+	PushTypeLiveActivity EPushType = "liveactivity"
 )
 
 const (

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -2,7 +2,9 @@ package payload_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/sideshow/apns2/payload"
 	"github.com/stretchr/testify/assert"
@@ -234,4 +236,41 @@ func TestCombined(t *testing.T) {
 	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").InterruptionLevel(InterruptionLevelActive).RelevanceScore(0.1).Custom("key", "val")
 	b, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"interruption-level":"active","relevance-score":0.1,"sound":"Default.caf"},"key":"val"}`, string(b))
+}
+
+func TestContentState(t *testing.T) {
+	payload := NewPayload().ContentState(map[string]interface{}{
+		"content": "bar",
+		"state":   "new",
+		"title":   "foo",
+	})
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"content-state":{"content":"bar","state":"new","title":"foo"}}}`, string(b))
+}
+
+func TestEvent(t *testing.T) {
+	payload := NewPayload().Event(LiveActivityEventUpdate)
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"event":"update"}}`, string(b))
+}
+
+func TestTimestamp(t *testing.T) {
+	timestamp := time.Now().Unix()
+	payload := NewPayload().Timestamp(timestamp)
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, fmt.Sprintf(`{"aps":{"timestamp":%d}}`, timestamp), string(b))
+}
+
+func TestStaleDate(t *testing.T) {
+	timestamp := time.Now().Unix()
+	payload := NewPayload().StaleDate(timestamp)
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, fmt.Sprintf(`{"aps":{"stale-date":%d}}`, timestamp), string(b))
+}
+
+func TestDismissalDate(t *testing.T) {
+	timestamp := time.Now().Unix()
+	payload := NewPayload().DismissalDate(timestamp)
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, fmt.Sprintf(`{"aps":{"dismissal-date":%d}}`, timestamp), string(b))
 }


### PR DESCRIPTION
Добавил поддержку live activities:
- добавлен новый тип пушей `liveactivity`
- расширена структура пейлоада с поддержкой полей специфичных для live activity
- при отправке live activity пуша добавляется суффикс `push-type.liveactivity` в заголовок `apns-topic` при неободимости